### PR TITLE
When quickly adding and removing a large amount of nodes, Chrome 68 e…

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -189,7 +189,7 @@ export function renderComponent(component, renderMode, mountAll, isChild) {
 	}
 
 	if (!isUpdate || mountAll) {
-		mounts.unshift(component);
+		mounts.push(component);
 	}
 	else if (!skip) {
 		// Ensure that pending componentDidMount() hooks of child components

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -24,11 +24,13 @@ let hydrating = false;
 
 /** Invoke queued componentDidMount lifecycle methods */
 export function flushMounts() {
-	let c;
-	while ((c=mounts.pop())) {
+	let c, i;
+	for (i=0; i<mounts.length; ++i) {
+		c = mounts[i];
 		if (options.afterMount) options.afterMount(c);
 		if (c.componentDidMount) c.componentDidMount();
 	}
+	mounts.length = 0;
 }
 
 


### PR DESCRIPTION
…xperiences poor performance. Most of the time is spent in mounts.unshift(). Removing mounts.unshift and reversing the order that mounts are flushed.